### PR TITLE
Receive build notifications via Atomist

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -1,0 +1,16 @@
+---
+kind: "operation"
+client: "com.atomist:rug"
+version: "1.0.0-20170816122823"
+editor:
+  name: "AddTravisWebhookEditor"
+  group: "atomist"
+  artifact: "enrollment-rugs"
+  version: "0.3.68"
+  origin:
+    repo: "git@github.com:atomisthq/enrollment-rugs.git"
+    branch: "1ef47a3059e4fbb20326ff4365c4ef7f06502165"
+    sha: "1ef47a3"
+  parameters:
+    - "atomistWebhookUrl": "https://webhook.atomist.com/atomist/travis/teams/T1JVCMVH7"
+

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.atomist.yml linguist-generated=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,11 @@
 install:
   - i am the build definition
+notifications:
+  webhooks:
+    urls:
+    - 'https://webhook.atomist.com/atomist/travis/teams/T1JVCMVH7/undefined'
+    on_cancel: always
+    on_error: always
+    on_start: always
+    on_failure: always
+    on_success: always


### PR DESCRIPTION
Send build events to Atomist.

They'll be incorporated into GitHub push and PR notifications,
so you'll see dynamically updated build results along with your commits.
Look for them in this channel in Slack.

[Travis webhook documentation](https://docs.travis-ci.com/user/notifications/#Configuring-webhook-notifications)